### PR TITLE
bug fixing: turn assignment within an assert into a propper comparison

### DIFF
--- a/src/gbons2.cpp
+++ b/src/gbons2.cpp
@@ -988,7 +988,7 @@ const PointInfo& Worker::getPointInfo(int id) const {
 }
 
 PointInfo& Worker::getPointInfo(const Vertex_handle& _vh) {
-	assert(pointInfo.at(_vh->info()).id = _vh->info());
+	assert(pointInfo.at(_vh->info()).id == _vh->info());
 	return getPointInfo(_vh->info());
 }
 
@@ -1819,3 +1819,4 @@ main(int argc, char* argv[]) {
 	
 	return 0;
 }
+


### PR DESCRIPTION
There is an assingment (=) within an assert. Should be a comparison (==)